### PR TITLE
Adding a dash between slug and uuid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ function SlugsHook(sails) {
             sails.models[modelName].count(criteria)
             .then(function (found) {
               if (found) {
-                values[name] = slugName + uuid.v4();
+                values[name] = slugName + '-' + uuid.v4();
               }
               else {
                 values[name] = slugName;


### PR DESCRIPTION
When slug already exists, an uuid is added at the end. I added a dash between in order to have a better "SEO friendly" url.